### PR TITLE
Using XACML contained in GENIFF

### DIFF
--- a/privacy/src/Infrastructure/Balana.java
+++ b/privacy/src/Infrastructure/Balana.java
@@ -17,8 +17,12 @@ public class Balana {
     private static org.wso2.balana.Balana balana;
 
 
-    public static String evaluateRequest(String request) {
-        initBalana();
+    public static String evaluateRequest(String request){
+        return evaluateRequest(request, null);
+    }
+
+    public static String evaluateRequest(String request, String policyFileName) {
+        initBalana(policyFileName);
         try {
             PDP pdp = getPDPNewInstance();
             String response = pdp.evaluate(request);
@@ -35,12 +39,21 @@ public class Balana {
         return "";
     }
 
-    private static void initBalana() {
+    private static void initBalana(){
+        initBalana(null);
+    }
+
+    private static void initBalana(String policyFilename) {
         // using file based policy repository. so set the policy location as system property
         String policyLocation = null;
         String configPath = null;
         try {
-            policyLocation = (new File(".")).getCanonicalPath() + File.separator + "policy";
+            if (policyFilename==null) {
+                policyLocation = (new File(".")).getCanonicalPath() + File.separator + "policy/XACMLPolicy.xml";
+            }else{
+                policyLocation = policyFilename;
+            }
+            System.out.println("policyLocation: "+policyLocation);
             System.setProperty(FileBasedPolicyFinderModule.POLICY_DIR_PROPERTY, policyLocation);
         } catch (IOException e) {
             System.err.println("Can not locate policy repository");

--- a/privacy/src/application/service/CommandFactory.java
+++ b/privacy/src/application/service/CommandFactory.java
@@ -8,14 +8,16 @@ public class CommandFactory {
             }
             if(commandType.equalsIgnoreCase("VIEW")){
                 return new ViewSAM();
-
             } else if(commandType.equalsIgnoreCase("INDEX")){
                 return new Index();
-
             } else if(commandType.equalsIgnoreCase("VIEWCHROMOSOME")){
                 return new ViewChromosome();
             } else if(commandType.equalsIgnoreCase("SORT")){
                 return new Sort();
+            } else if (commandType.equalsIgnoreCase("EXTRACT_XACML")){
+                return new XACMLextractor();
+            } else if (commandType.equalsIgnoreCase("EXTRACT_DATA")){
+                return new DataExtractor();
             }
 
             return null;

--- a/privacy/src/application/service/DATAextractor.java
+++ b/privacy/src/application/service/DATAextractor.java
@@ -1,0 +1,18 @@
+package application.service;
+
+/**
+ * Created by gencom on 19/10/16.
+ */
+public class DATAextractor extends Command{
+    @Override
+    public void execute(String file) {
+        System.out.println("extracting xacml...");
+        String fileNameWithoutExtn = file.substring(0, file.lastIndexOf('.'));
+        String command = "./writtingGenISOBMFF decode " + fileNameWithoutExtn + ".geniff " + "DATA";
+        System.out.println(command);
+
+        String output = executeCommand(command);
+        System.out.println(output);
+        System.out.println("\n========OUTPUT======");
+    }
+}

--- a/privacy/src/application/service/DataExtractor.java
+++ b/privacy/src/application/service/DataExtractor.java
@@ -1,0 +1,18 @@
+package application.service;
+
+/**
+ * Created by gencom on 19/10/16.
+ */
+public class DataExtractor extends Command {
+    @Override
+    public void execute(String file) {
+        System.out.println("extracting data...");
+        String fileNameWithoutExtn = file.substring(0, file.lastIndexOf('.'));
+        String command = "./writtingGenISOBMFF decode " + fileNameWithoutExtn + ".geniff " + "DATA";
+        System.out.println(command);
+
+        String output = executeCommand(command);
+        System.out.println(output);
+        System.out.println("\n========OUTPUT======");
+    }
+}

--- a/privacy/src/application/service/IndexExtractor.java
+++ b/privacy/src/application/service/IndexExtractor.java
@@ -1,0 +1,18 @@
+package application.service;
+
+/**
+ * Created by gencom on 19/10/16.
+ */
+public class IndexExtractor extends Command{
+    @Override
+    public void execute(String file) {
+        System.out.println("extracting xacml...");
+        String fileNameWithoutExtn = file.substring(0, file.lastIndexOf('.'));
+        String command = "./writtingGenISOBMFF decode " + fileNameWithoutExtn + ".geniff " + "INDEX";
+        System.out.println(command);
+
+        String output = executeCommand(command);
+        System.out.println(output);
+        System.out.println("\n========OUTPUT======");
+    }
+}

--- a/privacy/src/application/service/ViewChromosome.java
+++ b/privacy/src/application/service/ViewChromosome.java
@@ -1,5 +1,11 @@
 package application.service;
 
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.File;
+
+import static java.lang.System.exit;
+
 public class ViewChromosome extends Command {
 
     @Override
@@ -8,8 +14,41 @@ public class ViewChromosome extends Command {
         String fileWithoutExtn = fileWithoutRef.substring(0, fileWithoutRef.lastIndexOf('.'));
         String chromosomeRef = file.substring(file.lastIndexOf("#") + 1);
 
-        viewSAM(fileWithoutRef);
-        IndexBam(fileWithoutExtn);
+        String fileExtension = fileWithoutRef.substring(fileWithoutRef.lastIndexOf('.')+1);
+
+        if (fileExtension.equalsIgnoreCase("sam")) {
+            viewSAM(fileWithoutRef);
+            IndexBam(fileWithoutExtn);
+        }else if(fileExtension.equalsIgnoreCase("geniff")){
+            getBAM(file);
+            System.out.println("BAM obtained");
+            getBAI(file);
+            System.out.println("BAI obtained");
+
+            String filename_dir = FilenameUtils.getPath(fileWithoutRef);
+            if (filename_dir.isEmpty()) filename_dir=".";
+            File directory= new File(filename_dir);
+            if (directory.isDirectory()){
+                boolean bam_found = false;
+                for(File file_in_directory:directory.listFiles()){
+                    String file_in_directory_name = file_in_directory.getName();
+                    String file_in_directory_extension = file_in_directory_name.substring(file_in_directory_name.lastIndexOf('.')+1);
+                    if(file_in_directory_extension.equalsIgnoreCase("bam")){
+                        if (bam_found){
+                            System.err.println("too many BAM files in the directory");
+                            exit(-1);
+                        }else{
+                            String bamFileName = file_in_directory.getAbsolutePath();
+                            fileWithoutExtn = filename_dir+bamFileName.substring(bamFileName.lastIndexOf('/')+1, bamFileName.lastIndexOf('.'));
+                            bam_found = true;
+                        }
+                    }
+                }
+            }else{
+                System.err.println("Error in the geniff file location provided");
+                exit(-1);
+            }
+        }
         String command = "samtools view -h " + fileWithoutExtn + ".bam " + chromosomeRef;
         
         String output = executeCommand(command);
@@ -25,5 +64,15 @@ public class ViewChromosome extends Command {
     private void viewSAM(String file) {
         Command ViewSAM = new ViewSAM();
         ViewSAM.execute(file);
+    }
+
+    private void getBAM(String filename){
+        DATAextractor dataExtractor = new DATAextractor();
+        dataExtractor.execute(filename);
+    }
+
+    private void getBAI(String filename){
+        IndexExtractor extractor = new IndexExtractor();
+        extractor.execute(filename);
     }
 }

--- a/privacy/src/application/service/ViewSAM.java
+++ b/privacy/src/application/service/ViewSAM.java
@@ -1,7 +1,10 @@
 package application.service;
 
+import org.apache.commons.io.FilenameUtils;
 
-import java.text.Normalizer;
+import java.io.File;
+
+import static java.lang.System.exit;
 
 public class ViewSAM extends Command {
 
@@ -9,12 +12,56 @@ public class ViewSAM extends Command {
     public void execute(String file) {
         System.out.println("viewing samtools...");
         String fileNameWithoutExtn = file.substring(0, file.lastIndexOf('.'));
-        String commandView = "samtools view -b -S -o ";
-        String command = commandView + fileNameWithoutExtn + ".bam " + file;
+
+        String fileExtension = file.substring(file.lastIndexOf('.')+1);
+
+        String command = null;
+        if (fileExtension.equalsIgnoreCase("sam")) {
+            String commandView = "samtools view -b -S -o ";
+            command = commandView + fileNameWithoutExtn + ".bam " + file;
+        }else if(fileExtension.equalsIgnoreCase("geniff")){
+            getBAM(file);
+
+            String filename_dir = FilenameUtils.getPath(file);
+            String bamFileName = null;
+            if (filename_dir.isEmpty()) filename_dir=".";
+            File directory= new File(filename_dir);
+            if (directory.isDirectory()){
+                boolean bam_found = false;
+                for(File file_in_directory:directory.listFiles()){
+                    String file_in_directory_name = file_in_directory.getName();
+                    String file_in_directory_extension = file_in_directory_name.substring(file_in_directory_name.lastIndexOf('.')+1);
+                    if(file_in_directory_extension.equalsIgnoreCase("bam")){
+                        if (bam_found){
+                            System.err.println("too many BAM files in the directory");
+                            exit(-1);
+                        }else{
+                            bamFileName = file_in_directory.getAbsolutePath();
+                            bam_found = true;
+                        }
+                    }
+                }
+                if(bam_found){
+                    command = "samtools view -H " + bamFileName;
+                }else{
+                    System.err.println("BAM file not properly generated from geniff");
+                    exit(-1);
+                }
+            }else{
+                System.err.println("Error in the geniff file location provided");
+                exit(-1);
+            }
+        }
+
         System.out.println(command);
 
         String output = executeCommand(command);
         System.out.println(output);
         System.out.println("\n========OUTPUT======");
+    }
+
+    private void getBAM(String filename){
+        DATAextractor dataExtractor = new DATAextractor();
+        dataExtractor.execute(filename);
     }
 }

--- a/privacy/src/application/service/XACMLextractor.java
+++ b/privacy/src/application/service/XACMLextractor.java
@@ -1,0 +1,18 @@
+package application.service;
+
+/**
+ * Created by gencom on 19/10/16.
+ */
+public class XACMLextractor extends Command{
+    @Override
+    public void execute(String file) {
+        System.out.println("extracting xacml...");
+        String fileNameWithoutExtn = file.substring(0, file.lastIndexOf('.'));
+        String command = "./writtingGenISOBMFF decode " + fileNameWithoutExtn + ".geniff " + "XACML";
+        System.out.println(command);
+
+        String output = executeCommand(command);
+        System.out.println(output);
+        System.out.println("\n========OUTPUT======");
+    }
+}


### PR DESCRIPTION
This pull requests proposes a draft of how to use the XACML contained in a GENIFF file. As a matter of fact, it uses also the data and index contained in the GENIFF.
It is still a very early draft: the executable for GENIFF handling has to be present in the working directory, and it only works with GENIFF files with only one BAM file within it. It also requires the XACML and the BAI to be present.
